### PR TITLE
fix: make overflowing content scroll inside of the main div

### DIFF
--- a/src/lib/components/Nav.svelte
+++ b/src/lib/components/Nav.svelte
@@ -58,7 +58,7 @@
 <header
 	class="sticky top-0 z-50 w-full border-b bg-background shadow-lg backdrop-blur rounded-md"
 >
-	<div class="flex px-8 h-14 items-center">
+	<div class="flex p-8 h-14 items-center">
 		<div class="mr-4 hidden md:flex">
 			<a class="mr-6 flex items-center space-x-2" href="/dashboard">
 				<span class="hidden font-bold sm:inline-block text-[15px] lg:text-base"

--- a/src/routes/dashboard/+layout.svelte
+++ b/src/routes/dashboard/+layout.svelte
@@ -8,7 +8,7 @@
 
 <Nav></Nav>
 <div
-	class="flex-1 w-full bg-background shadow-lg space-y-4 p-8 pt-6 rounded-md"
+	class="flex flex-col h-full overflow-auto w-full bg-background shadow-lg space-y-4 p-8 pt-6 rounded-md"
 >
 	<slot />
 </div>

--- a/src/routes/dashboard/division/rosters/+page.svelte
+++ b/src/routes/dashboard/division/rosters/+page.svelte
@@ -117,6 +117,13 @@
 								</Table.Row>
 							{/if}
 						{/each}
+						{#each new Array(100) as []}
+							<Table.Row>
+								<Table.Cell>1</Table.Cell>
+								<Table.Cell>1</Table.Cell>
+								<Table.Cell>1</Table.Cell>
+							</Table.Row>
+						{/each}
 					</Table.Body>
 				</Table.Root>
 			</Card.Content>


### PR DESCRIPTION
- Make padding of nav uniform
- Content overflows inside of the main content div instead of the entire page