### PR TITLE
manage/createrole/: fix permission type in schema

### DIFF
--- a/src/routes/[id]/manage/createrole/schema.ts
+++ b/src/routes/[id]/manage/createrole/schema.ts
@@ -8,7 +8,7 @@ let baseSchema = {
 
 for (let permission of PERMISSIONS) {
   // @ts-ignore
-  baseSchema[permission.id] = z.boolean();
+  baseSchema[permission.id] = z.preprocess((x) => String(x) === 'on', z.any());
 }
 
 export const formSchema = z.object(baseSchema);


### PR DESCRIPTION
Fix createrole bug where all permissions return as true even when unchecked.

# Problem Statement

The permissions were enforced to be boolean by the schema, which makes sense. However, the form data response were having a different behavior and this method defaulted all permissions as boolean true.

```js
// ./schema.ts
baseSchema[permission.id] = z.boolean();
```

output:

```js
{
  name: 'testrole',
  color: 'rose-500',
  'facility.editDetails': true,
  'roster.extendedView': true,
  'roster.assignRole': true,
  'training.certificate.issue': true,
  'training.certificate.revoke': true,
  'training.queues.recommend': true,
  'training.queues.manage': true,
  'training.train': true,
  'resource.manage': true,
  'resource.viewPrivate': true,
  'training.certificate.issue.solo': true,
  'training.certificate.issue.openskies': true,
  'training.certificate.revoke.solo': true,
  'training.certificate.revoke.openskies': true,
  'events.manage': true,
  'training.request.assign': true,
  'training.request.selfassign': true,
  'training.request.delete': true
}
```

When we change the schema type to `z.any()`, the following output is observed:

```js
{
  name: 'testrole',
  color: 'rose-500',
  'facility.editDetails': 'on',
  'roster.extendedView': 'undefined',
  'roster.assignRole': 'undefined',
  'training.certificate.issue': 'undefined',
  'training.certificate.revoke': 'undefined',
  'training.queues.recommend': 'undefined',
  'training.queues.manage': 'undefined',
  'training.train': 'undefined',
  'resource.manage': 'undefined',
  'resource.viewPrivate': 'undefined',
  'training.certificate.issue.solo': 'undefined',
  'training.certificate.issue.openskies': 'undefined',
  'training.certificate.revoke.solo': 'undefined',
  'training.certificate.revoke.openskies': 'undefined',
  'events.manage': 'undefined',
  'training.request.assign': 'undefined',
  'training.request.selfassign': 'undefined',
  'training.request.delete': 'undefined'
}
```

From the output above, it is concluded that the form data switch returns either a '`on'` or an `'undefined'` of type `string`. 

# The solution

Until we find a method to change the form's response behavior, the following approach enforces the permissions to be either a boolean true or false based on the response given by the data form:

```js
// ./schema.ts
baseSchema[permission.id] = z.preprocess((x) => String(x) === 'on', z.any());
```

Output:
```js
{
  name: 'testrole',
  color: 'rose-500',
  'facility.editDetails': true,
  'roster.extendedView': false,
  'roster.assignRole': false,
  'training.certificate.issue': false,
  'training.certificate.revoke': false,
  'training.queues.recommend': false,
  'training.queues.manage': false,
  'training.train': false,
  'resource.manage': false,
  'resource.viewPrivate': false,
  'training.certificate.issue.solo': false,
  'training.certificate.issue.openskies': false,
  'training.certificate.revoke.solo': false,
  'training.certificate.revoke.openskies': false,
  'events.manage': false,
  'training.request.assign': false,
  'training.request.selfassign': false,
  'training.request.delete': false
}
```

# Another solution

Another solution that also worked is to link the permission names directly to the `Form.Switch` tag. This solution may not be directly compatible with the schema though.