### PR TITLE
Add training queue view

### DIFF
--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -24,3 +24,26 @@ export function humanReadableDateOnly(d: Date): string {
 
   return new Intl.DateTimeFormat("en-US", options).format(d);
 }
+
+export function relativeTime(fromDate: Date, toDate: Date = new Date()) {
+  const units = [
+    { max: 1000 * 60, name: "second", divisor: 1000 },
+    { max: 1000 * 60 * 60, name: "minute", divisor: 1000 * 60 },
+    { max: 1000 * 60 * 60 * 24, name: "hour", divisor: 1000 * 60 * 60 },
+    {
+      max: 1000 * 60 * 60 * 24 * 30,
+      name: "day",
+      divisor: 1000 * 60 * 60 * 24,
+    },
+  ];
+
+  const millis = fromDate.getTime() - toDate.getTime();
+
+  const unit = units.find((u) => Math.abs(millis) < u.max);
+  if (!unit) return "Unknown";
+
+  const difference = Math.round(millis / unit.divisor);
+
+  const rtf = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
+  return rtf.format(difference, unit.name as any);
+}

--- a/src/routes/[id]/training/queues/[queueId]/+page.server.ts
+++ b/src/routes/[id]/training/queues/[queueId]/+page.server.ts
@@ -4,8 +4,6 @@ import type { PageServerLoad } from './$types';
 export const load: PageServerLoad = async ({ params, depends }) => {
     depends("queue:data");
 
-    console.log("Running load function...");
-
     let queue = await prisma.trainingQueue.findUnique({
         where: {
             id: params.queueId,

--- a/src/routes/[id]/training/queues/[queueId]/+page.server.ts
+++ b/src/routes/[id]/training/queues/[queueId]/+page.server.ts
@@ -1,0 +1,25 @@
+import prisma from '$lib/prisma';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ params, depends }) => {
+    depends("queue:data");
+
+    console.log("Running load function...");
+
+    let queue = await prisma.trainingQueue.findUnique({
+        where: {
+            id: params.queueId,
+        },
+        include: {
+            members: {
+                include: {
+                    user: true,
+                }
+            }
+        }
+    });
+
+    return {
+        queue,
+    };
+}

--- a/src/routes/[id]/training/queues/[queueId]/+page.svelte
+++ b/src/routes/[id]/training/queues/[queueId]/+page.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import type { PageData } from "./$types";
+  import DataTable from "./data-table.svelte";
+
+  export let data: PageData;
+
+  $: members = data.queue?.members;
+</script>
+
+<div class="flex items-center justify-between">
+  <h2 class="text-3xl font-bold tracking-tight">{data.queue?.name}</h2>
+</div>
+
+{#if members && members.length > 0}
+  <DataTable {members} />
+{:else}
+  <p>No members in this queue.</p>
+{/if}

--- a/src/routes/[id]/training/queues/[queueId]/data-table-actions.svelte
+++ b/src/routes/[id]/training/queues/[queueId]/data-table-actions.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+  import * as DropdownMenu from "$lib/components/ui/dropdown-menu";
+  import { Button } from "$lib/components/ui/button";
+  import { MoreHorizontal } from "lucide-svelte";
+  import { page } from "$app/stores";
+  import { toast } from "svelte-sonner";
+  import { goto, invalidate } from "$app/navigation";
+  import { can } from "$lib/perms/can";
+  import { MANAGE_QUEUES } from "$lib/perms/permissions";
+
+  export let id: string;
+
+  const removeUser = async (id: string) => {
+    await goto(
+      `/${$page.params.id}/training/queues/${$page.params.queueId}/remove/${id}`,
+    );
+
+    invalidate("queue:data");
+  };
+</script>
+
+<DropdownMenu.Root>
+  <DropdownMenu.Trigger asChild let:builder>
+    <Button
+      variant="ghost"
+      builders={[builder]}
+      size="icon"
+      class="relative w-8 h-8 p-0">
+      <span class="sr-only">Open menu</span>
+      <MoreHorizontal class="w-4 h-4" />
+    </Button>
+  </DropdownMenu.Trigger>
+  <DropdownMenu.Content>
+    <DropdownMenu.Group>
+      <DropdownMenu.Label>Actions</DropdownMenu.Label>
+      <DropdownMenu.Item
+        on:click={() => {
+          navigator.clipboard.writeText(id);
+          toast.success("CID copied to clipboard!");
+        }}>
+        Copy CID
+      </DropdownMenu.Item>
+    </DropdownMenu.Group>
+
+    <DropdownMenu.Separator />
+
+    {#if can(MANAGE_QUEUES)}
+      <DropdownMenu.Group>
+        <DropdownMenu.Item on:click={() => removeUser(id)}>
+          Remove from list
+        </DropdownMenu.Item>
+      </DropdownMenu.Group>
+    {/if}
+  </DropdownMenu.Content>
+</DropdownMenu.Root>

--- a/src/routes/[id]/training/queues/[queueId]/data-table.svelte
+++ b/src/routes/[id]/training/queues/[queueId]/data-table.svelte
@@ -1,0 +1,129 @@
+<script lang="ts">
+  import {
+    createRender,
+    createTable,
+    Render,
+    Subscribe,
+  } from "svelte-headless-table";
+  import { readable } from "svelte/store";
+  import DataTableActions from "./data-table-actions.svelte";
+  import * as Table from "$lib/components/ui/table";
+  import { addPagination } from "svelte-headless-table/plugins";
+  import { Button } from "$lib/components/ui/button";
+  import type { TrainingQueueMembership } from "@prisma/client";
+
+  export let members: TrainingQueueMembership[];
+
+  const timeString = (joinedAt: Date): string => {
+    const now = new Date();
+
+    const diff = now.getTime() - joinedAt.getTime();
+
+    const sec = Math.floor(diff / 1000);
+    const min = Math.floor(sec / 60);
+    const hr = Math.floor(min / 60);
+    const day = Math.floor(hr / 24);
+
+    if (day > 0) {
+      return `${day} day${day > 1 ? "s" : ""}`;
+    } else if (hr > 0) {
+      return `${hr} hour${hr > 1 ? "s" : ""}`;
+    } else if (min > 0) {
+      return `${min} minute${min > 1 ? "s" : ""}`;
+    } else {
+      return `${sec} second${sec > 1 ? "s" : ""}`;
+    }
+  };
+
+  const table = createTable(readable(members), {
+    page: addPagination(),
+  });
+
+  const columns = table.createColumns([
+    table.column({
+      accessor: (member: any) => member.user.name,
+      header: "Name",
+    }),
+    table.column({
+      accessor: (member: any) => member.user.id,
+      header: "CID",
+    }),
+    table.column({
+      accessor: (member: TrainingQueueMembership) =>
+        member.joinedAt.toDateString(),
+      header: "Joined at",
+    }),
+    table.column({
+      accessor: (member: TrainingQueueMembership) =>
+        timeString(member.joinedAt),
+      header: "Waiting time",
+    }),
+    table.column({
+      accessor: (member: any) => member.user.id,
+      header: "",
+      cell: ({ value }) => {
+        return createRender(DataTableActions, {
+          id: value,
+        });
+      },
+    }),
+  ]);
+
+  const { headerRows, pageRows, tableAttrs, tableBodyAttrs, pluginStates } =
+    table.createViewModel(columns);
+
+  const { hasNextPage, hasPreviousPage, pageIndex } = pluginStates.page;
+</script>
+
+<div>
+  <div class="rounded-md border">
+    <Table.Root {...$tableAttrs}>
+      <Table.Header>
+        {#each $headerRows as headerRow}
+          <Subscribe rowAttrs={headerRow.attrs()}>
+            <Table.Row>
+              {#each headerRow.cells as cell (cell.id)}
+                <Subscribe attrs={cell.attrs()} let:attrs props={cell.props()}>
+                  <Table.Head {...attrs}>
+                    <Render of={cell.render()} />
+                  </Table.Head>
+                </Subscribe>
+              {/each}
+            </Table.Row>
+          </Subscribe>
+        {/each}
+      </Table.Header>
+      <Table.Body {...$tableBodyAttrs}>
+        {#each $pageRows as row (row.id)}
+          <Subscribe rowAttrs={row.attrs()} let:rowAttrs>
+            <Table.Row {...rowAttrs}>
+              {#each row.cells as cell (cell.id)}
+                <Subscribe attrs={cell.attrs()} let:attrs>
+                  <Table.Cell {...attrs}>
+                    <Render of={cell.render()} />
+                  </Table.Cell>
+                </Subscribe>
+              {/each}
+            </Table.Row>
+          </Subscribe>
+        {/each}
+      </Table.Body>
+    </Table.Root>
+  </div>
+  <div class="flex items-center justify-end space-x-2 py-4">
+    <Button
+      variant="outline"
+      size="sm"
+      on:click={() => ($pageIndex = $pageIndex - 1)}
+      disabled={!$hasPreviousPage}>
+      Previous
+    </Button>
+    <Button
+      variant="outline"
+      size="sm"
+      disabled={!$hasNextPage}
+      on:click={() => ($pageIndex = $pageIndex + 1)}>
+      Next
+    </Button>
+  </div>
+</div>

--- a/src/routes/[id]/training/queues/[queueId]/data-table.svelte
+++ b/src/routes/[id]/training/queues/[queueId]/data-table.svelte
@@ -11,29 +11,9 @@
   import { addPagination } from "svelte-headless-table/plugins";
   import { Button } from "$lib/components/ui/button";
   import type { TrainingQueueMembership } from "@prisma/client";
+  import { relativeTime } from "$lib/date";
 
   export let members: TrainingQueueMembership[];
-
-  const timeString = (joinedAt: Date): string => {
-    const now = new Date();
-
-    const diff = now.getTime() - joinedAt.getTime();
-
-    const sec = Math.floor(diff / 1000);
-    const min = Math.floor(sec / 60);
-    const hr = Math.floor(min / 60);
-    const day = Math.floor(hr / 24);
-
-    if (day > 0) {
-      return `${day} day${day > 1 ? "s" : ""}`;
-    } else if (hr > 0) {
-      return `${hr} hour${hr > 1 ? "s" : ""}`;
-    } else if (min > 0) {
-      return `${min} minute${min > 1 ? "s" : ""}`;
-    } else {
-      return `${sec} second${sec > 1 ? "s" : ""}`;
-    }
-  };
 
   const table = createTable(readable(members), {
     page: addPagination(),
@@ -50,13 +30,13 @@
     }),
     table.column({
       accessor: (member: TrainingQueueMembership) =>
-        member.joinedAt.toDateString(),
-      header: "Joined at",
+        relativeTime(member.joinedAt),
+      header: "Joined queue",
     }),
     table.column({
       accessor: (member: TrainingQueueMembership) =>
-        timeString(member.joinedAt),
-      header: "Waiting time",
+        member.joinedAt.toDateString(),
+      header: "Join date",
     }),
     table.column({
       accessor: (member: any) => member.user.id,

--- a/src/routes/[id]/training/queues/[queueId]/remove/[userId]/+page.server.ts
+++ b/src/routes/[id]/training/queues/[queueId]/remove/[userId]/+page.server.ts
@@ -1,0 +1,28 @@
+import prisma from '$lib/prisma';
+import { redirect } from 'sveltekit-flash-message/server';
+import type { PageServerLoad } from './$types';
+import { can } from '$lib/perms/can';
+import { MANAGE_QUEUES } from '$lib/perms/permissions';
+
+export const load: PageServerLoad = async ({ params, cookies }) => {
+    if (can(MANAGE_QUEUES)) {
+        redirect(307, `/${params.id}/training/queues/${params.queueId}`, {
+            type: "error",
+            message: "You do not have permission to do that",
+        }, cookies)
+    }
+
+    await prisma.trainingQueueMembership.deleteMany({
+        where: {
+            userId: params.userId,
+            queueId: params.queueId,
+        }
+    });
+
+    redirect(
+        301,
+        `/${params.id}/training/queues/${params.queueId}`,
+        { type: "success", message: "Removed user from queue successfully" },
+        cookies
+    );
+}

--- a/src/routes/[id]/training/queues/manage/data-table-actions.svelte
+++ b/src/routes/[id]/training/queues/manage/data-table-actions.svelte
@@ -33,6 +33,12 @@
       </DropdownMenu.Item>
     </DropdownMenu.Group>
 
+    <DropdownMenu.Separator />
+
+    <DropdownMenu.Item href="/{$page.params.id}/training/queues/{id}">
+      View queue
+    </DropdownMenu.Item>
+
     {#if can(RECOMMEND_FOR_QUEUE)}
       <DropdownMenu.Separator />
 

--- a/src/routes/admin/connections/+page.svelte
+++ b/src/routes/admin/connections/+page.svelte
@@ -4,6 +4,7 @@
   import * as Table from "$lib/components/ui/table";
   import type { PageData } from "./$types";
   import type { Connection, User } from "@prisma/client";
+  import { relativeTime } from "$lib/date";
 
   export let data: PageData;
 
@@ -42,29 +43,6 @@
 
   const { headerRows, pageRows, tableAttrs, tableBodyAttrs } =
     table.createViewModel(columns);
-
-  function relativeTime(fromDate: Date, toDate: Date = new Date()) {
-    const units = [
-      { max: 1000 * 60, name: "second", divisor: 1000 },
-      { max: 1000 * 60 * 60, name: "minute", divisor: 1000 * 60 },
-      { max: 1000 * 60 * 60 * 24, name: "hour", divisor: 1000 * 60 * 60 },
-      {
-        max: 1000 * 60 * 60 * 24 * 30,
-        name: "day",
-        divisor: 1000 * 60 * 60 * 24,
-      },
-    ];
-
-    const millis = fromDate.getTime() - toDate.getTime();
-
-    const unit = units.find((u) => Math.abs(millis) < u.max);
-    if (!unit) return "Unknown";
-
-    const difference = Math.round(millis / unit.divisor);
-
-    const rtf = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
-    return rtf.format(difference, unit.name as any);
-  }
 </script>
 
 <div class="flex items-center justify-between">


### PR DESCRIPTION
This PR adds a view wherein staff can inspect the full list of members in a given training queue, and allows them to remove members from the queue within that view.

Closes #32 
<hr />
<img width="112" alt="e0e24abba155d1a71d516c1f4c512cce" src="https://github.com/VATMENA/hayya/assets/8169427/ee653fb4-843f-4d85-a9f0-b5a106cde631"><br />
Updated action menu on "Manage Training Queues" page (with "View queue" option)
<hr />
<img width="925" alt="fb222608ba374f0616c90b1b58008a8b" src="https://github.com/VATMENA/hayya/assets/8169427/c065cfb0-7555-41cc-be14-0cf0ed3d4961">
New training queue view page