### PR TITLE
Feat: all markdown features

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hq",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "private": true,
   "scripts": {
     "dev": "concurrently -c bgGreen,bgBlue -n vite,quirrel 'vite dev --port 5173' 'quirrel'",

--- a/src/app.pcss
+++ b/src/app.pcss
@@ -75,4 +75,56 @@
   body {
     @apply bg-background text-foreground;
   }
+
+  .render h1 {
+    @apply scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-5xl;
+  }
+  .render h2 {
+    @apply scroll-m-20 pb-2 text-3xl font-semibold tracking-tight transition-colors first:mt-0;
+  }
+  .render h3 {
+    @apply scroll-m-20 text-2xl font-semibold tracking-tight;
+  }
+  .render h4 {
+    @apply scroll-m-20 text-xl font-semibold tracking-tight;
+  }
+  .render p {
+    @apply leading-7 [&:not(:first-child)]:mt-6;
+  }
+  .render blockquote {
+    @apply mt-6 border-l-2 pl-6 italic;
+  }
+
+  .render a {
+    font-weight: 500;
+    text-decoration: underline;
+    text-underline-offset: 4px;
+  }
+
+  .render ul {
+    @apply list-disc list-inside my-6 [&>li]:mt-2;
+  }
+  .render ol {
+    @apply list-decimal list-inside my-6 [&>li]:mt-2;
+  }
+
+  .render pre {
+    @apply relative rounded bg-muted px-[0.3rem] py-[0.2rem] font-mono text-sm font-semibold block w-min;
+  }
+
+  .render table {
+    @apply my-6 w-full overflow-y-auto;
+  }
+  .render table > thead > tr {
+    @apply m-0 border-t p-0 even:bg-muted;
+  }
+  .render table > thead > tr > th {
+    @apply border px-4 py-2 text-left font-bold [&[align=center]]:text-center [&[align=right]]:text-right;
+  }
+  .render table > tbody > tr {
+    @apply m-0 border-t p-0 even:bg-muted;
+  }
+  .render table > tbody > tr > td {
+    @apply border px-4 py-2 text-left [&[align=center]]:text-center [&[align=right]]:text-right;
+  }
 }

--- a/src/lib/components/Markdown.svelte
+++ b/src/lib/components/Markdown.svelte
@@ -19,39 +19,3 @@
 {:catch error}
   Error rendering: {error}
 {/await}
-
-<style lang="postcss">
-  .render :global(h1) {
-    scroll-margin: 5rem;
-    font-size: 2.25rem; /* 36px */
-    line-height: 2.5rem; /* 40px */
-    font-weight: 800;
-    letter-spacing: -0.025em;
-  }
-  .render :global(h2) {
-    scroll-margin: 5rem;
-    font-size: 1.875rem; /* 30px */
-    line-height: 2.25rem; /* 36px */
-    font-weight: 700;
-    letter-spacing: -0.025em;
-  }
-  .render :global(h3) {
-    scroll-margin: 5rem;
-    font-size: 1.5rem; /* 24px */
-    line-height: 2rem; /* 32px */
-    font-weight: 600;
-    letter-spacing: -0.025em;
-  }
-  .render :global(h4) {
-    scroll-margin: 5rem;
-    font-size: 1.25rem; /* 20px */
-    line-height: 1.75rem; /* 28px */
-    font-weight: 500;
-    letter-spacing: -0.025em;
-  }
-  .render :global(a) {
-    font-weight: 500;
-    text-decoration: underline;
-    text-underline-offset: 4px;
-  }
-</style>

--- a/src/routes/[id]/tvc/cases/[caseId]/+page.server.ts
+++ b/src/routes/[id]/tvc/cases/[caseId]/+page.server.ts
@@ -10,9 +10,14 @@ import { TVCaseState, TVCaseType } from "@prisma/client";
 export const load: PageServerLoad = async ({ parent, cookies, params }) => {
   let { user } = await parent();
 
+  let id = Number.parseInt(params.caseId);
+  if (!id || isNaN(id)) {
+    return {};
+  }
+
   let tvCase = await prisma.tVCase.findUnique({
     where: {
-      id: Number.parseInt(params.caseId),
+      id: id,
       facilityId: params.id,
     },
     include: {

--- a/src/routes/[id]/tvc/cases/[caseId]/+page.server.ts
+++ b/src/routes/[id]/tvc/cases/[caseId]/+page.server.ts
@@ -11,9 +11,6 @@ export const load: PageServerLoad = async ({ parent, cookies, params }) => {
   let { user } = await parent();
 
   let id = Number.parseInt(params.caseId);
-  if (!id || isNaN(id)) {
-    return {};
-  }
 
   let tvCase = await prisma.tVCase.findUnique({
     where: {


### PR DESCRIPTION
Adds all remaining Markdown features to the <Markdown/> component.

Closes #49.
Closes HAY-124.

Adds the following Markdown features:
- H1 `#`
- H2 `##`
- H3 `###`
- bold & italic text
- blockquotes
- numbered lists
- bulleted lists
- horizontal rules
- links
- tables
- inline code blocks
- strikethrough