### PR TITLE
hotfix: nixpkgs use pnpm 9.x

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,2 @@
+[phases.setup]
+nixPkgs = ['nodejs_18', 'pnpm-9_x', 'openssl']


### PR DESCRIPTION
Updates pnpm in the nixpacks pipeline to pnpm 9.x