### PR TITLE
fix: remove old events data-table, show visibility of events on card

### DIFF
--- a/src/lib/components/ui/carousel/carousel-item.svelte
+++ b/src/lib/components/ui/carousel/carousel-item.svelte
@@ -1,25 +1,24 @@
 <script lang="ts">
-	import type { HTMLAttributes } from "svelte/elements";
-	import { getEmblaContext } from "./context.js";
-	import { cn } from "$lib/utils.js";
+  import type { HTMLAttributes } from "svelte/elements";
+  import { getEmblaContext } from "./context.js";
+  import { cn } from "$lib/utils.js";
 
-	type $$Props = HTMLAttributes<HTMLDivElement>;
-	let className: string | undefined | null = undefined;
-	export { className as class };
+  type $$Props = HTMLAttributes<HTMLDivElement>;
+  let className: string | undefined | null = undefined;
+  export { className as class };
 
-	const { orientation } = getEmblaContext("<Carousel.Item/>");
+  const { orientation } = getEmblaContext("<Carousel.Item/>");
 </script>
 
 <div
-	role="group"
-	aria-roledescription="slide"
-	class={cn(
-		"min-w-0 shrink-0 grow-0 basis-full",
-		$orientation === "horizontal" ? "pl-4" : "pt-4",
-		className
-	)}
-	data-embla-slide=""
-	{...$$restProps}
->
-	<slot />
+  role="group"
+  aria-roledescription="slide"
+  class={cn(
+    "min-w-0 shrink-0 grow-0 basis-full",
+    $orientation === "horizontal" ? "pl-4" : "pt-4",
+    className,
+  )}
+  data-embla-slide=""
+  {...$$restProps}>
+  <slot />
 </div>

--- a/src/routes/[id]/events/+page.svelte
+++ b/src/routes/[id]/events/+page.svelte
@@ -102,11 +102,15 @@
 </div>
 
 {#if data.events.length > 0}
-  <Carousel.Root class="max-w-full mx-12">
-    <Carousel.Content class="m-3">
+  <Carousel.Root class="flex mx-12 h-full items-center">
+    <Carousel.Content class="m-3 h-full">
       {#each data.events as event (event.id)}
-        {#if event.public}
-          <Carousel.Item class="md:basis-1/2 lg:basis-1/4">
+        {#if canManageEvents}
+          <Carousel.Item class="lg:basis-1/2 h-full">
+            <EventCard {event} />
+          </Carousel.Item>
+        {:else if event.public}
+          <Carousel.Item class="lg:basis-1/2 h-full">
             <EventCard {event} />
           </Carousel.Item>
         {/if}
@@ -117,6 +121,7 @@
   </Carousel.Root>
 {/if}
 
+<!--
 {#if canManageEvents}
   <Table.Root {...$tableAttrs}>
     <Table.Header>
@@ -150,7 +155,7 @@
       {/each}
     </Table.Body>
   </Table.Root>
-{/if}
+{/if} -->
 
 <!--
 <Table.Root>

--- a/src/routes/[id]/events/event-card.svelte
+++ b/src/routes/[id]/events/event-card.svelte
@@ -10,6 +10,8 @@
 
   export let event: Event;
 
+  let canManageEvents = can(MANAGE_EVENTS);
+
   const formatter = new Intl.DateTimeFormat("en-GB", {
     timeZone: "UTC",
     weekday: "long",
@@ -22,23 +24,34 @@
 
 <a href={`/${event.hostId}/events/${event.id}`}>
   <Card.Root
-    class="max-w-xs mr-4 mb-4 h-fit md:h-full transform transition-transform hover:scale-[1.02] pb-4">
+    class="w-full mr-4 mb-4 h-fit md:h-full transition hover:scale-[1.02]">
     <img
       src={event.bannerUrl}
       class="rounded-t-lg h-1/2 object-cover"
       alt={`${event.name} event banner`} />
-    <Card.Header class="font-bold text-lg py-3">{event.name}</Card.Header>
-    <Card.Content class="flex grow">
-      <p>{event.description}</p>
+    <Card.Header class="font-bold text-3xl py-3">{event.name}</Card.Header>
+    <Card.Content>
+      <!-- <div class="truncate">{event.description}</div> -->
     </Card.Content>
-    <Card.Footer class="font-bold mb-4 float-bottom">
-      {#if event.start.getDate() === event.end.getDate()}
-        {formatter.format(event.start).replace(" at", "")}z - {event.end.getUTCHours()}:{event.end.getUTCMinutes()}z
-      {:else}
-        {formatter.format(event.start).replace(" at", "")}z - {formatter
-          .format(event.end)
-          .replace(" at", "")}z
-      {/if}
+    <Card.Footer class="flex flex-col items-start">
+      <div class="font-bold">
+        {#if event.start.getDate() === event.end.getDate()}
+          {formatter.format(event.start).replace(" at", "")}z - {event.end.getUTCHours()}:{event.end.getUTCMinutes()}z
+        {:else}
+          {formatter.format(event.start).replace(" at", "")}z - {formatter
+            .format(event.end)
+            .replace(" at", "")}z
+        {/if}
+      </div>
+      <div>
+        {#if canManageEvents}
+          <div class="text-xs">
+            Visibility (STAFF ONLY): <span class="font-bold">
+              {event.public ? "Public" : "Private"}
+            </span>
+          </div>
+        {/if}
+      </div>
     </Card.Footer>
   </Card.Root>
 </a>


### PR DESCRIPTION
- Removed old events data table.
- Updated cards to stop overflowing of long descriptions, (descriptions not really needed on the card, can be shown on the event page)
<img width="1375" alt="image" src="https://github.com/VATMENA/hayya/assets/14109339/e265d2ba-136e-40f5-8e12-94b8c3064729">
- Shows all events, public or private for members with the manage event perm, else normal members only see public events.